### PR TITLE
codex: fix uuid typings for Vercel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/node": "20.12.7",
     "@types/react": "18.2.67",
     "@types/react-dom": "18.2.22",
+    "@types/uuid": "^9.0.0",
     "autoprefixer": "10.4.17",
     "eslint": "8.57.0",
     "eslint-config-next": "14.1.0",

--- a/src/lib/datastore/local.ts
+++ b/src/lib/datastore/local.ts
@@ -1,5 +1,5 @@
 import { get, set } from "idb-keyval";
-import { v4 as uuid } from "uuid";
+import { v4 as uuidv4 } from "uuid";
 import dayjs from "dayjs";
 import { zSessionQuick } from "@/lib/schema/zod";
 
@@ -29,7 +29,7 @@ export async function addSession(input: unknown) {
   assertClient();
   const parsed = zSessionQuick.parse(input);
   const record: SessionRecord = {
-    id: uuid(),
+    id: uuidv4(),
     createdAt: new Date().toISOString(),
     syncState: "pending",
     ...parsed,


### PR DESCRIPTION
Error: Vercel build failed with "Could not find a declaration file for module 'uuid'."

- 目的: Vercel の Next.js ビルドで 'uuid' の型が解決できず失敗していたため、@types/uuid を追加し import を uuidv4 に統一。
- 影響範囲: 型のみ（ランタイムの挙動変更なし）。

------
https://chatgpt.com/codex/tasks/task_e_68ca2e002198832caf6cf107ed2bb504