### PR TITLE
Fix Vercel python handler

### DIFF
--- a/api/debug_env.py
+++ b/api/debug_env.py
@@ -1,14 +1,36 @@
-import os, json
+import json
+import os
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler
 
-def handler(request):
-    v = os.environ.get("NEWS_API_KEY")
-    body = json.dumps({"hasKey": bool(v), "len": (len(v) if v else 0)})
-    return (
-        body,
-        200,
-        {
-            "Content-Type": "application/json",
-            "Cache-Control": "no-store",
-            "Access-Control-Allow-Origin": os.environ.get("ALLOWED_ORIGIN", "*"),
-        },
-    )
+
+class Handler(BaseHTTPRequestHandler):
+    def _write_common_headers(self) -> None:
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header(
+            "Access-Control-Allow-Origin", os.environ.get("ALLOWED_ORIGIN", "*")
+        )
+        self.send_header("Access-Control-Allow-Methods", "GET, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+
+    def do_OPTIONS(self) -> None:  # noqa: N802 (Vercel expects lowercase handler)
+        self.send_response(HTTPStatus.NO_CONTENT)
+        self._write_common_headers()
+        self.end_headers()
+
+    def do_GET(self) -> None:  # noqa: N802 (Vercel expects lowercase handler)
+        api_key = os.environ.get("NEWS_API_KEY")
+        body = json.dumps(
+            {"hasKey": bool(api_key), "len": (len(api_key) if api_key else 0)}
+        ).encode("utf-8")
+
+        self.send_response(HTTPStatus.OK)
+        self._write_common_headers()
+        self.end_headers()
+        self.wfile.write(body)
+
+
+# Vercel looks for a ``handler`` attribute on the module, so expose the
+# ``Handler`` class under that name.
+handler = Handler


### PR DESCRIPTION
## Summary
- replace the tuple-based handler implementation with an HTTP handler class so the Vercel runtime can load it
- return the same JSON payload while sending appropriate headers for CORS and caching
- expose the `Handler` class while aliasing it as `handler` so it satisfies the runtime expectations without violating class naming conventions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca77b57590832c986897a97c17ec15