### PR TITLE
Add log editing and per-type practice summaries

### DIFF
--- a/src/app/log/[id]/edit/page.tsx
+++ b/src/app/log/[id]/edit/page.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import dayjs from "dayjs";
+import { useEffect, useMemo, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { DS } from "@/lib/datastore";
+
+type Session = Awaited<ReturnType<typeof DS.getSession>>;
+
+const TYPES = ["striking", "wrestling", "grappling", "tactics"] as const;
+
+type SessionType = (typeof TYPES)[number];
+
+export default function EditLogPage() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const sessionId = params?.id;
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [session, setSession] = useState<Session | null>(null);
+
+  const [date, setDate] = useState("");
+  const [startTime, setStartTime] = useState("");
+  const [type, setType] = useState<SessionType>("wrestling");
+  const [durationMin, setDurationMin] = useState<number>(60);
+  const [tags, setTags] = useState("");
+  const [memo, setMemo] = useState("");
+
+  useEffect(() => {
+    let active = true;
+    if (!sessionId || Array.isArray(sessionId)) {
+      setError("ログが見つかりませんでした");
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    DS.getSession(sessionId)
+      .then((data) => {
+        if (!active) return;
+        if (!data) {
+          setError("ログが見つかりませんでした");
+          return;
+        }
+        setSession(data);
+        setError(null);
+        setDate(data.date);
+        setStartTime(data.startTime ?? "");
+        const nextType = TYPES.includes(data.type as SessionType)
+          ? (data.type as SessionType)
+          : "wrestling";
+        setType(nextType);
+        setDurationMin(data.durationMin);
+        setTags(data.tags?.join(",") ?? "");
+        setMemo(data.memo ?? "");
+      })
+      .catch((err) => {
+        console.error(err);
+        if (!active) return;
+        setError("ログの読み込みに失敗しました");
+      })
+      .finally(() => {
+        if (!active) return;
+        setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [sessionId]);
+
+  const formattedCreatedAt = useMemo(() => {
+    if (!session?.createdAt) return null;
+    return dayjs(session.createdAt).format("YYYY/MM/DD HH:mm");
+  }, [session?.createdAt]);
+
+  async function handleSubmit() {
+    if (!sessionId || Array.isArray(sessionId)) return;
+    setSaving(true);
+    try {
+      const payload = {
+        date,
+        startTime: startTime || undefined,
+        type,
+        durationMin,
+        tags: tags
+          .split(",")
+          .map((item) => item.trim())
+          .filter(Boolean)
+          .slice(0, 3),
+        memo: memo || undefined,
+      };
+      await DS.updateSession(sessionId, payload);
+      router.push("/log");
+    } catch (err) {
+      console.error(err);
+      alert("更新に失敗しました");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-xl p-4">
+      <Card>
+        <CardHeader className="space-y-1">
+          <CardTitle>練習ログを編集</CardTitle>
+          {formattedCreatedAt ? (
+            <p className="text-xs text-muted-foreground">記録日時: {formattedCreatedAt}</p>
+          ) : null}
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {loading ? (
+            <div className="text-sm text-muted-foreground">読み込み中…</div>
+          ) : error ? (
+            <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+              {error}
+            </div>
+          ) : (
+            <>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <div>
+                  <Label htmlFor="date">日付</Label>
+                  <Input
+                    id="date"
+                    type="date"
+                    value={date}
+                    onChange={(event) => setDate(event.target.value)}
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="startTime">開始時刻</Label>
+                  <Input
+                    id="startTime"
+                    type="time"
+                    value={startTime}
+                    onChange={(event) => setStartTime(event.target.value)}
+                  />
+                </div>
+              </div>
+
+              <div>
+                <Label>種別</Label>
+                <Select value={type} onValueChange={(value) => setType(value as SessionType)}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {TYPES.map((item) => (
+                      <SelectItem key={item} value={item}>
+                        {item}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div>
+                <Label htmlFor="duration">時間(分)</Label>
+                <Input
+                  id="duration"
+                  type="number"
+                  min={1}
+                  value={durationMin}
+                  onChange={(event) => {
+                    const parsed = parseInt(event.target.value, 10);
+                    setDurationMin(Number.isNaN(parsed) ? 1 : Math.max(1, parsed));
+                  }}
+                />
+              </div>
+
+              <div>
+                <Label htmlFor="tags">技術タグ（カンマ区切り / 最大3）</Label>
+                <Input
+                  id="tags"
+                  placeholder="double_leg, knee_slide_pass"
+                  value={tags}
+                  onChange={(event) => setTags(event.target.value)}
+                />
+              </div>
+
+              <div>
+                <Label htmlFor="memo">メモ（任意）</Label>
+                <Textarea
+                  id="memo"
+                  rows={3}
+                  value={memo}
+                  onChange={(event) => setMemo(event.target.value)}
+                />
+              </div>
+
+              <div className="flex items-center gap-2">
+                <Button disabled={saving} onClick={handleSubmit}>
+                  更新
+                </Button>
+                <Button variant="outline" onClick={() => router.back()}>
+                  戻る
+                </Button>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -63,6 +63,39 @@ export default function LogListPage() {
     return sessions.reduce((total, session) => total + session.durationMin, 0);
   }, [sessions]);
 
+  const typeSummary = useMemo(() => {
+    const monthSet = new Set<string>();
+    const totals: Record<string, number> = {};
+    const monthly: Record<string, Record<string, number>> = {};
+
+    sessions.forEach((session) => {
+      const month = dayjs(session.date).format("YYYY-MM");
+      monthSet.add(month);
+      const type = session.type;
+      totals[type] = (totals[type] ?? 0) + session.durationMin;
+      if (!monthly[type]) {
+        monthly[type] = {};
+      }
+      monthly[type][month] = (monthly[type][month] ?? 0) + session.durationMin;
+    });
+
+    const baseOrder = Object.keys(TYPE_LABELS);
+    const dataTypes = Array.from(new Set(sessions.map((session) => session.type)));
+    const typeOrder = [...baseOrder, ...dataTypes.filter((type) => !baseOrder.includes(type))];
+    typeOrder.forEach((type) => {
+      totals[type] = totals[type] ?? 0;
+      monthly[type] = monthly[type] ?? {};
+    });
+
+    const months = Array.from(monthSet).sort(
+      (a, b) => dayjs(`${b}-01`).valueOf() - dayjs(`${a}-01`).valueOf(),
+    );
+
+    return { typeOrder, totals, monthly, months };
+  }, [sessions]);
+
+  const numberFormatter = useMemo(() => new Intl.NumberFormat("ja-JP"), []);
+
   return (
     <div className="mx-auto max-w-3xl space-y-4 p-4 md:p-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
@@ -102,6 +135,51 @@ export default function LogListPage() {
           )}
         </CardContent>
       </Card>
+
+      <Card>
+        <CardHeader className="space-y-1">
+          <CardTitle>種別ごとの練習時間</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            種別別の合計時間と月ごとの内訳を確認できます。
+          </p>
+        </CardHeader>
+        <CardContent>
+          {sessions.length === 0 ? (
+            <div className="text-sm text-muted-foreground">まだ集計できる記録がありません。</div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[480px] text-sm">
+                <thead>
+                  <tr className="border-b border-border">
+                    <th className="px-3 py-2 text-left font-medium">種別</th>
+                    <th className="px-3 py-2 text-right font-medium">合計(分)</th>
+                    {typeSummary.months.map((month) => (
+                      <th key={month} className="px-3 py-2 text-right font-medium">
+                        {dayjs(`${month}-01`).format("YYYY/MM")}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {typeSummary.typeOrder.map((type) => (
+                    <tr key={type} className="border-b border-border last:border-b-0">
+                      <td className="px-3 py-2">{TYPE_LABELS[type] ?? type}</td>
+                      <td className="px-3 py-2 text-right">
+                        {numberFormatter.format(typeSummary.totals[type] ?? 0)}
+                      </td>
+                      {typeSummary.months.map((month) => (
+                        <td key={month} className="px-3 py-2 text-right">
+                          {numberFormatter.format(typeSummary.monthly[type]?.[month] ?? 0)}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }
@@ -118,9 +196,14 @@ function SessionCard({ session }: { session: Session }) {
     <div className="space-y-2 rounded-lg border border-border p-3">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="text-sm font-medium text-muted-foreground">{dateLabel}</div>
-        <div className="flex items-center gap-2 text-sm font-medium">
-          <Badge>{TYPE_LABELS[session.type] ?? session.type}</Badge>
-          <span>{session.durationMin} 分</span>
+        <div className="flex items-center gap-1">
+          <div className="flex items-center gap-2 text-sm font-medium">
+            <Badge>{TYPE_LABELS[session.type] ?? session.type}</Badge>
+            <span>{session.durationMin} 分</span>
+          </div>
+          <Button asChild size="sm" variant="ghost">
+            <Link href={`/log/${session.id}/edit`}>編集</Link>
+          </Button>
         </div>
       </div>
 

--- a/src/lib/datastore/local.ts
+++ b/src/lib/datastore/local.ts
@@ -55,6 +55,12 @@ export async function listSessions(params?: { from?: string; to?: string }) {
   });
 }
 
+export async function getSession(id: string) {
+  assertClient();
+  const list: SessionRecord[] = ((await get(KEY_SESSIONS)) as SessionRecord[] | undefined) ?? [];
+  return list.find((session) => session.id === id) ?? null;
+}
+
 export async function updateSession(id: string, patch: Partial<SessionRecord>) {
   assertClient();
   const list: SessionRecord[] = ((await get(KEY_SESSIONS)) as SessionRecord[] | undefined) ?? [];

--- a/src/lib/datastore/supabase.ts
+++ b/src/lib/datastore/supabase.ts
@@ -36,6 +36,10 @@ export async function listSessions(params?: { from?: string; to?: string }) {
   return Local.listSessions(params);
 }
 
+export async function getSession(id: string) {
+  return Local.getSession(id);
+}
+
 export async function updateSession(id: string, patch: Partial<LocalSession>) {
   const updated = await Local.updateSession(id, patch as any);
   if (!updated || !supabase) return updated;


### PR DESCRIPTION
## Summary
- add a dedicated edit page to revisit and update an existing practice log entry
- extend the datastore API with a getSession helper used by both local and Supabase modes
- enhance the log list with edit links and a per-type/month practice time summary table

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ceac5b3548832cbbdcaa5cfda55dd3