### PR TITLE
Add email password authentication flow

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { supabase } from "@/lib/supabase/client";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+type Status = "loading" | "success" | "error";
+
+export default function AuthCallbackPage() {
+  const router = useRouter();
+  const [status, setStatus] = useState<Status>("loading");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!supabase) {
+      setStatus("error");
+      setError("Supabase クライアントが利用できません。");
+      return;
+    }
+
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    supabase.auth
+      .getSessionFromUrl({ storeSession: true })
+      .then(({ error: urlError }) => {
+        if (urlError) {
+          setStatus("error");
+          setError(urlError.message);
+          return;
+        }
+        setStatus("success");
+        timeout = setTimeout(() => {
+          router.replace("/log");
+        }, 1200);
+      })
+      .catch((unknownError) => {
+        console.error("Supabase auth getSessionFromUrl error", unknownError);
+        setStatus("error");
+        setError("メール確認の処理に失敗しました。");
+      });
+
+    return () => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    };
+  }, [router]);
+
+  return (
+    <div className="mx-auto max-w-md space-y-4 p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>ログイン処理中</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm text-muted-foreground">
+          {status === "loading" ? (
+            <p>メールのリンクを検証しています…</p>
+          ) : status === "success" ? (
+            <p>確認が完了しました。まもなく画面が切り替わります。</p>
+          ) : (
+            <p>{error ?? "エラーが発生しました。再度お試しください。"}</p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { FormEvent, useEffect, useState } from "react";
+import { supabase } from "@/lib/supabase/client";
+import { useAuth } from "@/components/providers/auth-provider";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+type Mode = "signIn" | "signUp";
+
+export default function AuthPage() {
+  const router = useRouter();
+  const { session, supabaseAvailable } = useAuth();
+  const [mode, setMode] = useState<Mode>("signIn");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [passwordConfirm, setPasswordConfirm] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (session) {
+      router.replace("/log");
+    }
+  }, [router, session]);
+
+  if (!supabaseAvailable) {
+    return (
+      <div className="mx-auto max-w-md space-y-4 p-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>ログイン設定が無効です</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm text-muted-foreground">
+            <p>Supabase の公開 URL と anon キーが設定されていないため、ログイン機能を利用できません。</p>
+            <p>
+              <Link href="/" className="underline">
+                トップページに戻る
+              </Link>
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!supabase) {
+      setError("Supabase クライアントの初期化に失敗しました。");
+      return;
+    }
+    if (mode === "signUp" && password !== passwordConfirm) {
+      setError("確認用パスワードが一致しません。");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    setMessage(null);
+
+    try {
+      if (mode === "signUp") {
+        const redirectUrl = `${window.location.origin}/auth/callback`;
+        const { error: signUpError } = await supabase.auth.signUp({
+          email,
+          password,
+          options: { emailRedirectTo: redirectUrl },
+        });
+        if (signUpError) throw signUpError;
+        setMessage("確認メールを送信しました。メール内のリンクからサインインを完了してください。");
+      } else {
+        const { error: signInError } = await supabase.auth.signInWithPassword({
+          email,
+          password,
+        });
+        if (signInError) throw signInError;
+        setMessage("ログインに成功しました。練習ログに移動します。");
+        router.push("/log");
+      }
+    } catch (error) {
+      if (error && typeof error === "object" && "message" in error) {
+        setError(String(error.message));
+      } else {
+        setError("予期しないエラーが発生しました。");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-md space-y-4 p-4">
+      <Card>
+        <CardHeader className="space-y-1">
+          <CardTitle>メールアドレスで{mode === "signIn" ? "ログイン" : "新規登録"}</CardTitle>
+        </CardHeader>
+        <form onSubmit={handleSubmit}>
+          <CardContent className="space-y-4">
+            <div className="space-y-1">
+              <Label htmlFor="email">メールアドレス</Label>
+              <Input
+                id="email"
+                type="email"
+                autoComplete="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="password">パスワード</Label>
+              <Input
+                id="password"
+                type="password"
+                autoComplete={mode === "signIn" ? "current-password" : "new-password"}
+                value={password}
+                minLength={6}
+                onChange={(event) => setPassword(event.target.value)}
+                required
+              />
+            </div>
+            {mode === "signUp" ? (
+              <div className="space-y-1">
+                <Label htmlFor="passwordConfirm">パスワード（確認用）</Label>
+                <Input
+                  id="passwordConfirm"
+                  type="password"
+                  autoComplete="new-password"
+                  value={passwordConfirm}
+                  minLength={6}
+                  onChange={(event) => setPasswordConfirm(event.target.value)}
+                  required
+                />
+              </div>
+            ) : null}
+            {error ? (
+              <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+                {error}
+              </div>
+            ) : null}
+            {message ? (
+              <div className="rounded-md border border-border bg-muted/30 p-3 text-sm text-muted-foreground">
+                {message}
+              </div>
+            ) : null}
+          </CardContent>
+          <CardFooter className="flex flex-col gap-3">
+            <Button type="submit" disabled={loading} className="w-full">
+              {mode === "signIn" ? "ログイン" : "登録メールを送信"}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={loading}
+              onClick={() => {
+                setMode(mode === "signIn" ? "signUp" : "signIn");
+                setError(null);
+                setMessage(null);
+              }}
+            >
+              {mode === "signIn" ? "新規登録はこちら" : "既にアカウントをお持ちの方はこちら"}
+            </Button>
+            <Button type="button" variant="outline" asChild>
+              <Link href="/">トップに戻る</Link>
+            </Button>
+          </CardFooter>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,8 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 import { ReactNode } from "react";
 import ClientPWA from "@/components/providers/client-pwa";
+import { AuthProvider } from "@/components/providers/auth-provider";
+import AppShell from "@/components/layout/app-shell";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
 
@@ -16,7 +18,11 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="ja" suppressHydrationWarning>
       <body className={`${inter.variable} min-h-screen bg-background text-foreground`}>
-        <ClientPWA>{children}</ClientPWA>
+        <ClientPWA>
+          <AuthProvider>
+            <AppShell>{children}</AppShell>
+          </AuthProvider>
+        </ClientPWA>
       </body>
     </html>
   );

--- a/src/app/log/[id]/edit/page.tsx
+++ b/src/app/log/[id]/edit/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import dayjs from "dayjs";
+import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
@@ -10,6 +11,7 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { DS } from "@/lib/datastore";
+import { useAuth } from "@/components/providers/auth-provider";
 
 type Session = Awaited<ReturnType<typeof DS.getSession>>;
 
@@ -32,6 +34,9 @@ export default function EditLogPage() {
   const [durationMin, setDurationMin] = useState<number>(60);
   const [tags, setTags] = useState("");
   const [memo, setMemo] = useState("");
+  const { session, loading: authLoading, supabaseAvailable } = useAuth();
+
+  const loginRequired = supabaseAvailable && !authLoading && !session;
 
   useEffect(() => {
     let active = true;
@@ -123,6 +128,14 @@ export default function EditLogPage() {
             </div>
           ) : (
             <>
+              {loginRequired ? (
+                <div className="space-y-2 rounded-md border border-border bg-muted/30 p-3 text-sm text-muted-foreground">
+                  <p>ログインするとこの編集内容が Supabase に同期されます。</p>
+                  <Button asChild size="sm" variant="outline" className="text-xs">
+                    <Link href="/auth">ログインページを開く</Link>
+                  </Button>
+                </div>
+              ) : null}
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                 <div>
                   <Label htmlFor="date">日付</Label>

--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { DS } from "@/lib/datastore";
+import { useAuth } from "@/components/providers/auth-provider";
 
 const TYPE_LABELS: Record<string, string> = {
   striking: "打撃",
@@ -22,6 +23,7 @@ export default function LogListPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
+  const { session, loading: authLoading, supabaseAvailable } = useAuth();
 
   useEffect(() => {
     let active = true;
@@ -98,6 +100,14 @@ export default function LogListPage() {
 
   return (
     <div className="mx-auto max-w-3xl space-y-4 p-4 md:p-6">
+      {supabaseAvailable && !authLoading && !session ? (
+        <div className="space-y-2 rounded-md border border-border bg-muted/30 p-3 text-sm text-muted-foreground">
+          <p>Supabase と同期するにはログインが必要です。ログイン後に自動的に再同期が実行されます。</p>
+          <Button asChild size="sm" variant="outline" className="text-xs">
+            <Link href="/auth">ログインページを開く</Link>
+          </Button>
+        </div>
+      ) : null}
       <div className="flex flex-wrap items-center justify-between gap-3">
         <h1 className="text-2xl font-semibold">練習ログ</h1>
         <div className="flex items-center gap-2">

--- a/src/app/log/quick/page.tsx
+++ b/src/app/log/quick/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import dayjs from "dayjs";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
@@ -10,6 +11,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { DS } from "@/lib/datastore";
+import { useAuth } from "@/components/providers/auth-provider";
 
 const TYPES = ["striking", "wrestling", "grappling", "tactics"] as const;
 
@@ -24,6 +26,9 @@ export default function QuickLogPage() {
   const [tags, setTags] = useState("");
   const [memo, setMemo] = useState("");
   const [saving, setSaving] = useState(false);
+  const { session, loading: authLoading, supabaseAvailable } = useAuth();
+
+  const loginRequired = supabaseAvailable && !authLoading && !session;
 
   async function onSubmit() {
     setSaving(true);
@@ -57,6 +62,14 @@ export default function QuickLogPage() {
           <CardTitle>クイック記録</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
+          {loginRequired ? (
+            <div className="space-y-2 rounded-md border border-border bg-muted/30 p-3 text-sm text-muted-foreground">
+              <p>ログインするとこの記録が Supabase に同期されます。</p>
+              <Button asChild size="sm" variant="outline" className="text-xs">
+                <Link href="/auth">ログインページを開く</Link>
+              </Button>
+            </div>
+          ) : null}
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div>
               <Label>日付</Label>

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import Link from "next/link";
+import { ReactNode, useState } from "react";
+import { useAuth } from "@/components/providers/auth-provider";
+import { Button } from "@/components/ui/button";
+
+export default function AppShell({ children }: { children: ReactNode }) {
+  const { session, loading, supabaseAvailable, signOut } = useAuth();
+  const [signingOut, setSigningOut] = useState(false);
+
+  const handleSignOut = async () => {
+    setSigningOut(true);
+    try {
+      await signOut();
+    } finally {
+      setSigningOut(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      {supabaseAvailable ? (
+        <header className="sticky top-0 z-20 border-b border-border bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+          <div className="mx-auto flex w-full max-w-5xl items-center justify-between gap-3 px-4 py-3">
+            <Link href="/" className="text-sm font-semibold uppercase tracking-wide">
+              MMA Roadmap
+            </Link>
+            <div className="flex items-center gap-3 text-sm">
+              {session ? (
+                <>
+                  {session.user.email ? (
+                    <span className="hidden text-muted-foreground sm:inline">
+                      {session.user.email}
+                    </span>
+                  ) : null}
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleSignOut}
+                    disabled={signingOut || loading}
+                  >
+                    ログアウト
+                  </Button>
+                </>
+              ) : (
+                <Button asChild size="sm" variant="outline">
+                  <Link href="/auth">ログイン</Link>
+                </Button>
+              )}
+            </div>
+          </div>
+        </header>
+      ) : null}
+      <main className="pb-12 pt-4 md:pt-6">{children}</main>
+    </div>
+  );
+}

--- a/src/components/providers/auth-provider.tsx
+++ b/src/components/providers/auth-provider.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { ReactNode, createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import type { Session } from "@supabase/supabase-js";
+import { supabase, isSupabaseConfigured } from "@/lib/supabase/client";
+
+type AuthContextValue = {
+  session: Session | null;
+  loading: boolean;
+  supabaseAvailable: boolean;
+  signOut: () => Promise<void>;
+};
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [session, setSession] = useState<Session | null>(null);
+  const [loading, setLoading] = useState<boolean>(isSupabaseConfigured);
+
+  useEffect(() => {
+    if (!supabase) {
+      setLoading(false);
+      return;
+    }
+
+    let active = true;
+
+    supabase.auth
+      .getSession()
+      .then(({ data, error }) => {
+        if (!active) return;
+        if (error) {
+          console.error("Supabase auth getSession error", error);
+        }
+        setSession(data.session ?? null);
+        setLoading(false);
+      })
+      .catch((error) => {
+        if (!active) return;
+        console.error("Supabase auth getSession error", error);
+        setLoading(false);
+      });
+
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, newSession) => {
+      if (!active) return;
+      setSession(newSession ?? null);
+      setLoading(false);
+    });
+
+    return () => {
+      active = false;
+      listener?.subscription.unsubscribe();
+    };
+  }, []);
+
+  const signOut = useCallback(async () => {
+    if (!supabase) return;
+    try {
+      await supabase.auth.signOut();
+    } catch (error) {
+      console.error("Supabase auth signOut error", error);
+    }
+  }, []);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      session,
+      loading,
+      supabaseAvailable: isSupabaseConfigured,
+      signOut,
+    }),
+    [loading, session, signOut]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return context;
+}

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,0 +1,9 @@
+import { createClient } from "@supabase/supabase-js";
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+export const supabase =
+  typeof window !== "undefined" && url && anonKey ? createClient(url, anonKey) : null;
+
+export const isSupabaseConfigured = Boolean(supabase);


### PR DESCRIPTION
## Summary
- replace the anonymous Supabase sign-in logic with a session check and guidance to log in before syncing
- add a client-side auth provider and app shell with login/logout controls backed by the Supabase session
- implement email/password login and signup screens plus a callback handler, and show login prompts on log pages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cef6e04508832c85c978b43c8e1c60