### PR TITLE
Enable Supabase-backed logs and add deletion control

### DIFF
--- a/src/app/log/[id]/edit/page.tsx
+++ b/src/app/log/[id]/edit/page.tsx
@@ -25,6 +25,7 @@ export default function EditLogPage() {
   const sessionId = params?.id;
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [logSession, setLogSession] = useState<Session | null>(null);
 
@@ -111,6 +112,23 @@ export default function EditLogPage() {
       alert("更新に失敗しました");
     } finally {
       setSaving(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!sessionId || Array.isArray(sessionId)) return;
+    if (!window.confirm("この練習ログを削除しますか？")) {
+      return;
+    }
+    setDeleting(true);
+    try {
+      await DS.deleteSession(sessionId);
+      router.push("/log");
+    } catch (err) {
+      console.error(err);
+      alert("削除に失敗しました");
+    } finally {
+      setDeleting(false);
     }
   }
 
@@ -211,12 +229,21 @@ export default function EditLogPage() {
                 />
               </div>
 
-              <div className="flex items-center gap-2">
-                <Button disabled={saving} onClick={handleSubmit}>
-                  更新
-                </Button>
-                <Button variant="outline" onClick={() => router.back()}>
-                  戻る
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex items-center gap-2">
+                  <Button disabled={saving} onClick={handleSubmit}>
+                    更新
+                  </Button>
+                  <Button variant="outline" onClick={() => router.back()}>
+                    戻る
+                  </Button>
+                </div>
+                <Button
+                  variant="destructive"
+                  disabled={deleting}
+                  onClick={handleDelete}
+                >
+                  {deleting ? "削除中..." : "このログを削除"}
                 </Button>
               </div>
             </>

--- a/src/lib/datastore/local.ts
+++ b/src/lib/datastore/local.ts
@@ -7,7 +7,7 @@ export type SyncState = "pending" | "synced" | "error";
 
 const KEY_SESSIONS = "sessions";
 
-type SessionRecord = {
+export type SessionRecord = {
   id: string;
   createdAt: string;
   syncState: SyncState;
@@ -76,6 +76,11 @@ export async function deleteSession(id: string) {
   const list: SessionRecord[] = ((await get(KEY_SESSIONS)) as SessionRecord[] | undefined) ?? [];
   const next = list.filter((session) => session.id !== id);
   await set(KEY_SESSIONS, next);
+}
+
+export async function replaceAllSessions(records: SessionRecord[]) {
+  assertClient();
+  await set(KEY_SESSIONS, records);
 }
 
 export async function markSynced(id: string) {


### PR DESCRIPTION
## Summary
- synchronize practice logs from Supabase when the user is authenticated
- persist remotely fetched sessions into IndexedDB while preserving pending local edits
- expose a destructive action on the edit page so a log entry can be removed

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf6b68186c832cace0251183470fb8