### PR TITLE
Add tag suggestions and analysis page

### DIFF
--- a/src/app/log/[id]/edit/page.tsx
+++ b/src/app/log/[id]/edit/page.tsx
@@ -6,12 +6,13 @@ import { useEffect, useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { DS } from "@/lib/datastore";
 import { useAuth } from "@/components/providers/auth-provider";
+import { Input } from "@/components/ui/input";
+import { TagInputWithSuggestions } from "@/components/log/tag-input-with-suggestions";
 
 type Session = Awaited<ReturnType<typeof DS.getSession>>;
 
@@ -211,11 +212,11 @@ export default function EditLogPage() {
 
               <div>
                 <Label htmlFor="tags">技術タグ（カンマ区切り / 最大3）</Label>
-                <Input
+                <TagInputWithSuggestions
                   id="tags"
                   placeholder="double_leg, knee_slide_pass"
                   value={tags}
-                  onChange={(event) => setTags(event.target.value)}
+                  onValueChange={setTags}
                 />
               </div>
 

--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -114,6 +114,9 @@ export default function LogListPage() {
           <Button variant="outline" onClick={handleRefresh} disabled={loading}>
             再読み込み
           </Button>
+          <Button variant="outline" asChild>
+            <Link href="/log/tag-analysis">タグ分析</Link>
+          </Button>
           <Button asChild>
             <Link href="/log/quick">＋ ログする</Link>
           </Button>

--- a/src/app/log/quick/page.tsx
+++ b/src/app/log/quick/page.tsx
@@ -6,12 +6,13 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { DS } from "@/lib/datastore";
 import { useAuth } from "@/components/providers/auth-provider";
+import { Input } from "@/components/ui/input";
+import { TagInputWithSuggestions } from "@/components/log/tag-input-with-suggestions";
 
 const TYPES = ["striking", "wrestling", "grappling", "tactics"] as const;
 
@@ -108,10 +109,10 @@ export default function QuickLogPage() {
 
           <div>
             <Label>技術タグ（カンマ区切り / 最大3）</Label>
-            <Input
+            <TagInputWithSuggestions
               placeholder="double_leg, knee_slide_pass"
               value={tags}
-              onChange={(event) => setTags(event.target.value)}
+              onValueChange={setTags}
             />
           </div>
 

--- a/src/app/log/tag-analysis/page.tsx
+++ b/src/app/log/tag-analysis/page.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import dayjs from "dayjs";
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { DS } from "@/lib/datastore";
+
+const TYPE_LABELS: Record<string, string> = {
+  striking: "打撃",
+  wrestling: "レスリング",
+  grappling: "グラップリング",
+  tactics: "戦術",
+};
+
+type Session = Awaited<ReturnType<typeof DS.listSessions>>[number];
+
+type TagEntry = {
+  tag: string;
+  sessions: Session[];
+  totalDuration: number;
+};
+
+export default function TagAnalysisPage() {
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    DS.listSessions()
+      .then((data) => {
+        if (!active) return;
+        setSessions(data);
+        setError(null);
+      })
+      .catch((err) => {
+        console.error(err);
+        if (!active) return;
+        setError("タグ情報の取得に失敗しました");
+      })
+      .finally(() => {
+        if (!active) return;
+        setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const tagEntries = useMemo(() => {
+    const map = new Map<string, Session[]>();
+    sessions.forEach((session) => {
+      session.tags?.forEach((tag) => {
+        const normalized = tag.trim();
+        if (!normalized) return;
+        if (!map.has(normalized)) {
+          map.set(normalized, []);
+        }
+        map.get(normalized)?.push(session);
+      });
+    });
+
+    return Array.from(map.entries())
+      .map(([tag, list]) => ({
+        tag,
+        sessions: list.sort((a, b) => {
+          const dateA = dayjs(`${a.date} ${a.startTime ?? "00:00"}`);
+          const dateB = dayjs(`${b.date} ${b.startTime ?? "00:00"}`);
+          return dateB.valueOf() - dateA.valueOf();
+        }),
+        totalDuration: list.reduce((total, item) => total + item.durationMin, 0),
+      }))
+      .sort((a, b) => {
+        if (b.sessions.length !== a.sessions.length) {
+          return b.sessions.length - a.sessions.length;
+        }
+        if (b.totalDuration !== a.totalDuration) {
+          return b.totalDuration - a.totalDuration;
+        }
+        return a.tag.localeCompare(b.tag);
+      });
+  }, [sessions]);
+
+  const numberFormatter = useMemo(() => new Intl.NumberFormat("ja-JP"), []);
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-4 p-4 md:p-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold">タグ分析</h1>
+          <p className="text-sm text-muted-foreground">
+            過去に付与したタグごとに、紐づく練習ログを確認できます。
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline" asChild>
+            <Link href="/log">ログ一覧へ戻る</Link>
+          </Button>
+          <Button asChild>
+            <Link href="/log/quick">＋ ログする</Link>
+          </Button>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader className="space-y-1">
+          <CardTitle>タグごとの内訳</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            タグの利用回数順に並べています。
+          </p>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="text-sm text-muted-foreground">読み込み中…</div>
+          ) : error ? (
+            <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+              {error}
+            </div>
+          ) : tagEntries.length === 0 ? (
+            <div className="text-sm text-muted-foreground">まだタグ付きの練習ログがありません。</div>
+          ) : (
+            <div className="space-y-4">
+              {tagEntries.map((entry) => (
+                <TagCard key={entry.tag} entry={entry} numberFormatter={numberFormatter} />
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+type TagCardProps = {
+  entry: TagEntry;
+  numberFormatter: Intl.NumberFormat;
+};
+
+function TagCard({ entry, numberFormatter }: TagCardProps) {
+  return (
+    <Card>
+      <CardHeader className="space-y-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant="secondary">#{entry.tag}</Badge>
+          <span className="text-sm text-muted-foreground">
+            {entry.sessions.length} 件 / 合計 {numberFormatter.format(entry.totalDuration)} 分
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {entry.sessions.map((session) => (
+          <div
+            key={session.id}
+            className="rounded-md border border-border bg-card/60 p-3 transition hover:border-primary"
+          >
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div className="space-y-1">
+                <div className="text-sm font-medium">
+                  {dayjs(session.date).format("YYYY/MM/DD")}
+                  {session.startTime ? ` ${session.startTime}` : ""}
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  種別: {TYPE_LABELS[session.type] ?? session.type} / {session.durationMin} 分
+                </div>
+              </div>
+              <Button size="sm" variant="outline" asChild>
+                <Link href={`/log/${session.id}/edit`}>詳細</Link>
+              </Button>
+            </div>
+            {session.memo ? (
+              <p className="mt-2 whitespace-pre-wrap text-sm text-muted-foreground">{session.memo}</p>
+            ) : null}
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/log/tag-input-with-suggestions.tsx
+++ b/src/components/log/tag-input-with-suggestions.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Input, InputProps } from "@/components/ui/input";
+import { cn } from "@/lib/util/cn";
+import { DS } from "@/lib/datastore";
+
+function normalizeTag(tag: string) {
+  return tag.trim();
+}
+
+type TagInputWithSuggestionsProps = Omit<InputProps, "value" | "onChange"> & {
+  value: string;
+  onValueChange: (value: string) => void;
+  maxSuggestions?: number;
+};
+
+type SessionForTags = Awaited<ReturnType<typeof DS.listSessions>>[number];
+
+type TagFrequency = {
+  tag: string;
+  count: number;
+};
+
+export function TagInputWithSuggestions({
+  value,
+  onValueChange,
+  className,
+  maxSuggestions = 5,
+  ...props
+}: TagInputWithSuggestionsProps) {
+  const [frequencies, setFrequencies] = useState<TagFrequency[]>([]);
+
+  useEffect(() => {
+    let active = true;
+    DS.listSessions()
+      .then((sessions) => {
+        if (!active) return;
+        const map = new Map<string, number>();
+        sessions.forEach((session: SessionForTags) => {
+          session.tags?.forEach((tag) => {
+            const normalized = normalizeTag(tag);
+            if (!normalized) return;
+            map.set(normalized, (map.get(normalized) ?? 0) + 1);
+          });
+        });
+        const sorted: TagFrequency[] = Array.from(map.entries())
+          .map(([tag, count]) => ({ tag, count }))
+          .sort((a, b) => {
+            if (b.count !== a.count) return b.count - a.count;
+            return a.tag.localeCompare(b.tag);
+          });
+        setFrequencies(sorted);
+      })
+      .catch((error) => {
+        console.error("タグ候補の読み込みに失敗しました", error);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const parsedTokens = useMemo(() => {
+    return value
+      .split(",")
+      .map((token) => token.trim())
+      .filter(Boolean);
+  }, [value]);
+
+  const activeToken = useMemo(() => {
+    if (!value) return "";
+    const segments = value.split(",");
+    if (segments.length === 0) return "";
+    return segments[segments.length - 1]?.trim() ?? "";
+  }, [value]);
+
+  const suggestions = useMemo(() => {
+    const query = activeToken.toLowerCase();
+    if (!query) return [];
+    const existing = new Set(parsedTokens.map((token) => token.toLowerCase()));
+    return frequencies
+      .filter((item) => item.tag.toLowerCase().includes(query) && !existing.has(item.tag.toLowerCase()))
+      .slice(0, maxSuggestions)
+      .map((item) => item.tag);
+  }, [activeToken, parsedTokens, frequencies, maxSuggestions]);
+
+  const handleSelect = (tag: string) => {
+    const hasTrailingComma = value.trim().endsWith(",");
+    const rawSegments = value.split(",");
+    const baseTokens = hasTrailingComma
+      ? parsedTokens
+      : rawSegments
+          .slice(0, Math.max(0, rawSegments.length - 1))
+          .map((segment) => segment.trim())
+          .filter(Boolean);
+    const nextTokens = [...baseTokens, tag];
+    onValueChange(nextTokens.join(", "));
+  };
+
+  return (
+    <div className="space-y-2">
+      <Input
+        value={value}
+        onChange={(event) => onValueChange(event.target.value)}
+        className={className}
+        {...props}
+      />
+      {suggestions.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {suggestions.map((tag) => (
+            <button
+              key={tag}
+              type="button"
+              className={cn(
+                "cursor-pointer rounded-full border border-transparent p-0 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              )}
+              onClick={() => handleSelect(tag)}
+            >
+              <Badge variant="secondary">#{tag}</Badge>
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable tag input that surfaces previously used tags as suggestions while typing
- integrate the suggestion input into the quick log and edit pages and add navigation to a new analysis view
- create a tag analysis page that lists each tag with its related practice logs and aggregates

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4c11b60ac832c8f03b92ba1d64f65