### PR TITLE
Add home calendar view for training logs

### DIFF
--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -3,18 +3,11 @@
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import dayjs from "dayjs";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { DS } from "@/lib/datastore";
 import { useAuth } from "@/components/providers/auth-provider";
-
-const TYPE_LABELS: Record<string, string> = {
-  striking: "打撃",
-  wrestling: "レスリング",
-  grappling: "グラップリング",
-  tactics: "戦術",
-};
+import { SessionCard, SESSION_TYPE_LABELS } from "@/components/log/session-card";
 
 type Session = Awaited<ReturnType<typeof DS.listSessions>> extends Array<infer T> ? T : never;
 
@@ -81,7 +74,7 @@ export default function LogListPage() {
       monthly[type][month] = (monthly[type][month] ?? 0) + session.durationMin;
     });
 
-    const baseOrder = Object.keys(TYPE_LABELS);
+    const baseOrder = Object.keys(SESSION_TYPE_LABELS);
     const dataTypes = Array.from(new Set(sessions.map((session) => session.type)));
     const typeOrder = [...baseOrder, ...dataTypes.filter((type) => !baseOrder.includes(type))];
     typeOrder.forEach((type) => {
@@ -126,9 +119,7 @@ export default function LogListPage() {
       <Card>
         <CardHeader className="space-y-1">
           <CardTitle>記録一覧</CardTitle>
-          <p className="text-sm text-muted-foreground">
-            合計 {sessions.length} 件 / {totalDuration} 分
-          </p>
+          <p className="text-sm text-muted-foreground">合計 {sessions.length} 件 / {totalDuration} 分</p>
         </CardHeader>
         <CardContent>
           {loading ? (
@@ -176,7 +167,7 @@ export default function LogListPage() {
                 <tbody>
                   {typeSummary.typeOrder.map((type) => (
                     <tr key={type} className="border-b border-border last:border-b-0">
-                      <td className="px-3 py-2">{TYPE_LABELS[type] ?? type}</td>
+                      <td className="px-3 py-2">{SESSION_TYPE_LABELS[type] ?? type}</td>
                       <td className="px-3 py-2 text-right">
                         {numberFormatter.format(typeSummary.totals[type] ?? 0)}
                       </td>
@@ -193,52 +184,6 @@ export default function LogListPage() {
           )}
         </CardContent>
       </Card>
-    </div>
-  );
-}
-
-function SessionCard({ session }: { session: Session }) {
-  const dateTime = session.startTime
-    ? dayjs(`${session.date} ${session.startTime}`)
-    : dayjs(session.date);
-  const dateLabel = session.startTime
-    ? dateTime.format("YYYY/MM/DD HH:mm")
-    : dateTime.format("YYYY/MM/DD");
-
-  return (
-    <div className="space-y-2 rounded-lg border border-border p-3">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <div className="text-sm font-medium text-muted-foreground">{dateLabel}</div>
-        <div className="flex items-center gap-1">
-          <div className="flex items-center gap-2 text-sm font-medium">
-            <Badge>{TYPE_LABELS[session.type] ?? session.type}</Badge>
-            <span>{session.durationMin} 分</span>
-          </div>
-          <Button asChild size="sm" variant="ghost">
-            <Link href={`/log/${session.id}/edit`}>編集</Link>
-          </Button>
-        </div>
-      </div>
-
-      {session.tags?.length ? (
-        <div className="flex flex-wrap gap-2">
-          {session.tags.map((tag, index) => (
-            <Badge key={`${session.id}-tag-${index}`} variant="outline">
-              #{tag}
-            </Badge>
-          ))}
-        </div>
-      ) : null}
-
-      {session.memo ? (
-        <p className="whitespace-pre-wrap text-sm leading-relaxed">{session.memo}</p>
-      ) : null}
-
-      {session.syncState !== "synced" ? (
-        <div className="text-xs text-amber-600">
-          {session.syncState === "pending" ? "同期待ち" : "同期エラー"}
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,106 +4,248 @@ export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
-import dayjs from "dayjs";
+import { useEffect, useMemo, useState } from "react";
+import dayjs, { type Dayjs } from "dayjs";
+
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { SessionCard, SESSION_TYPE_LABELS, type Session } from "@/components/log/session-card";
+import { DS } from "@/lib/datastore";
 import { cn } from "@/lib/util/cn";
 
-interface FocusItem {
-  technique_id: string;
-  reason: string[];
-  drills: string[];
+function createCalendarDays(month: Dayjs) {
+  const startOfMonth = month.startOf("month");
+  const startOffset = startOfMonth.day();
+  const firstDay = startOfMonth.subtract(startOffset, "day");
+  return Array.from({ length: 42 }, (_, index) => firstDay.add(index, "day"));
 }
 
-interface FocusResp {
-  date: string;
-  top3: FocusItem[];
-  warnings: string[];
-  hasSessionTomorrow?: boolean;
+function sortSessions(sessions: Session[]) {
+  return [...sessions].sort((a, b) => {
+    const dateA = dayjs(`${a.date} ${a.startTime ?? "00:00"}`);
+    const dateB = dayjs(`${b.date} ${b.startTime ?? "00:00"}`);
+    return dateA.valueOf() - dateB.valueOf();
+  });
 }
 
 export default function HomePage() {
-  const [data, setData] = useState<FocusResp | null>(null);
+  const [sessions, setSessions] = useState<Session[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const today = dayjs();
+  const [currentMonth, setCurrentMonth] = useState<Dayjs>(() => today.startOf("month"));
+  const [selectedDate, setSelectedDate] = useState(() => today.format("YYYY-MM-DD"));
 
   useEffect(() => {
-    let mounted = true;
-    (async () => {
-      try {
-        const response = await fetch("/api/recommendations?include_links=true", { cache: "no-store" });
-        if (!response.ok) throw new Error("failed to fetch");
-        const json: FocusResp = await response.json();
-        if (mounted) setData(json);
-      } catch (error) {
-        console.error(error);
-        if (mounted) {
-          setData({
-            date: dayjs().format("YYYY-MM-DD"),
-            top3: [
-              { technique_id: "double_leg", reason: ["review_due"], drills: ["ペネト3×10", "角度2×3R"] },
-              { technique_id: "knee_slide_pass", reason: ["tech_gap"], drills: ["解除→スライド 2×3R"] },
-              { technique_id: "jab_cross_low_kick", reason: ["balance_fix"], drills: ["シャドウ3R"] },
-            ],
-            warnings: [],
-            hasSessionTomorrow: false,
-          });
-        }
-      } finally {
-        if (mounted) setLoading(false);
-      }
-    })();
+    let active = true;
+    setLoading(true);
+    DS.listSessions()
+      .then((data) => {
+        if (!active) return;
+        setSessions(data);
+        setError(null);
+      })
+      .catch((err) => {
+        console.error(err);
+        if (!active) return;
+        setError("ログの読み込みに失敗しました");
+      })
+      .finally(() => {
+        if (!active) return;
+        setLoading(false);
+      });
 
     return () => {
-      mounted = false;
+      active = false;
     };
   }, []);
 
-  if (loading) {
-    return <div className="p-6 text-sm text-muted-foreground">読み込み中…</div>;
-  }
+  const sessionsByDate = useMemo(() => {
+    const map = new Map<string, Session[]>();
+    sessions.forEach((session) => {
+      const list = map.get(session.date) ?? [];
+      list.push(session);
+      map.set(session.date, list);
+    });
+    for (const [key, list] of map) {
+      map.set(key, sortSessions(list));
+    }
+    return map;
+  }, [sessions]);
 
-  const skipBanner = data?.hasSessionTomorrow === false;
+  const calendarDays = useMemo(() => createCalendarDays(currentMonth), [currentMonth]);
+
+  const selectedSessions = sessionsByDate.get(selectedDate) ?? [];
+  const selectedDayLabel = dayjs(selectedDate).format("YYYY年M月D日");
+  const monthLabel = currentMonth.format("YYYY年M月");
+  const monthlyTotals = useMemo(() => {
+    const totals: Record<string, number> = {};
+    sessions.forEach((session) => {
+      if (dayjs(session.date).isSame(currentMonth, "month")) {
+        totals[session.type] = (totals[session.type] ?? 0) + session.durationMin;
+      }
+    });
+    return totals;
+  }, [sessions, currentMonth]);
+  const orderedTypes = useMemo(() => {
+    const baseOrder = Object.keys(SESSION_TYPE_LABELS);
+    const extra = Object.keys(monthlyTotals).filter((type) => !baseOrder.includes(type));
+    return [...baseOrder, ...extra];
+  }, [monthlyTotals]);
+
+  const handleSelectDay = (day: Dayjs) => {
+    setSelectedDate(day.format("YYYY-MM-DD"));
+    setCurrentMonth(day.startOf("month"));
+  };
+
+  const handlePrevMonth = () => {
+    setCurrentMonth((prev) => {
+      const next = prev.subtract(1, "month");
+      setSelectedDate(next.format("YYYY-MM-DD"));
+      return next;
+    });
+  };
+
+  const handleNextMonth = () => {
+    setCurrentMonth((prev) => {
+      const next = prev.add(1, "month");
+      setSelectedDate(next.format("YYYY-MM-DD"));
+      return next;
+    });
+  };
 
   return (
     <div className="space-y-4 p-4 md:p-6">
-      <div className="flex justify-end">
-        <Button asChild variant="outline">
-          <Link href="/log">ログを見る</Link>
-        </Button>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold">ホーム</h1>
+          <p className="text-sm text-muted-foreground">カレンダーから練習ログを確認できます。</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" onClick={() => handleSelectDay(dayjs())}>今日</Button>
+          <Button asChild variant="outline">
+            <Link href="/log">一覧を見る</Link>
+          </Button>
+        </div>
       </div>
 
       <Card>
-        <CardHeader>
-          <CardTitle>今日の重点3つ</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          {data?.top3?.map((item, index) => (
-            <div key={item.technique_id + index} className="flex items-start justify-between gap-3 rounded-lg border border-border p-3">
-              <div>
-                <div className="font-semibold">{index + 1}) {item.technique_id}</div>
-                <div className="text-sm text-muted-foreground">理由: {item.reason.join(", ")}</div>
-                <div className="text-sm">ドリル: {item.drills.join(" / ")}</div>
-              </div>
-              <Button asChild size="sm">
-                <Link href="/log/quick">開始</Link>
+        <CardHeader className="space-y-1">
+          <CardTitle>練習カレンダー</CardTitle>
+          <div className="flex items-center justify-between text-sm text-muted-foreground">
+            <div>{monthLabel}</div>
+            <div className="flex items-center gap-2">
+              <Button variant="ghost" size="sm" onClick={handlePrevMonth}>
+                前の月
+              </Button>
+              <Button variant="ghost" size="sm" onClick={handleNextMonth}>
+                次の月
               </Button>
             </div>
-          ))}
+          </div>
+        </CardHeader>
+        <CardContent>
+          {error ? (
+            <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+              {error}
+            </div>
+          ) : null}
+          <div className="grid grid-cols-7 gap-1 text-center text-xs font-medium text-muted-foreground">
+            {[
+              "日",
+              "月",
+              "火",
+              "水",
+              "木",
+              "金",
+              "土",
+            ].map((label) => (
+              <div key={label} className="py-2">
+                {label}
+              </div>
+            ))}
+          </div>
+          <div className="grid grid-cols-7 gap-1">
+            {calendarDays.map((day) => {
+              const dateKey = day.format("YYYY-MM-DD");
+              const isCurrentMonth = day.month() === currentMonth.month();
+              const isToday = day.isSame(today, "day");
+              const isSelected = dateKey === selectedDate;
+              const hasSessions = sessionsByDate.has(dateKey);
+
+              return (
+                <button
+                  key={dateKey}
+                  type="button"
+                  onClick={() => handleSelectDay(day)}
+                  className={cn(
+                    "flex h-16 flex-col items-center justify-center rounded-md border text-sm transition",
+                    isSelected
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "border-transparent bg-muted/40 hover:border-border hover:bg-muted",
+                    !isCurrentMonth && "text-muted-foreground/60",
+                  )}
+                >
+                  <span className={cn("text-base font-medium", isToday && !isSelected && "text-primary")}>{day.date()}</span>
+                  <span className="text-[10px]">
+                    {hasSessions ? `${(sessionsByDate.get(dateKey) ?? []).length} 件` : ""}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
         </CardContent>
       </Card>
 
       <Card>
-        <CardHeader>
-          <CardTitle>次の予定</CardTitle>
+        <CardHeader className="space-y-1">
+          <CardTitle>{selectedDayLabel} のログ</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            {selectedSessions.length ? `${selectedSessions.length} 件の記録があります。` : "この日はまだ記録がありません。"}
+          </p>
         </CardHeader>
         <CardContent>
-          {skipBanner ? (
-            <div className={cn("rounded-md bg-muted p-3 text-sm text-muted-foreground")}>
-              明日は練習予定がありません。通知をスキップしました。
+          {loading ? (
+            <div className="text-sm text-muted-foreground">読み込み中…</div>
+          ) : selectedSessions.length === 0 ? (
+            <div className="text-sm text-muted-foreground">
+              {sessions.length === 0
+                ? "まずは右下のボタンから練習を記録してみましょう。"
+                : "選択した日に記録はありません。"}
             </div>
           ) : (
-            <div className="text-sm text-muted-foreground">明日の予定があればここに表示</div>
+            <div className="space-y-3">
+              {selectedSessions.map((session) => (
+                <SessionCard key={session.id} session={session} />
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="space-y-1">
+          <CardTitle>種別ごとの合計 (今月)</CardTitle>
+          <p className="text-sm text-muted-foreground">今月の練習時間をカテゴリ別に確認できます。</p>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="text-sm text-muted-foreground">集計中…</div>
+          ) : orderedTypes.length === 0 ? (
+            <div className="text-sm text-muted-foreground">まだ今月の記録がありません。</div>
+          ) : (
+            <div className="grid grid-cols-2 gap-3 text-sm md:grid-cols-4">
+              {orderedTypes.map((type) => {
+                const label = SESSION_TYPE_LABELS[type] ?? type;
+                const total = monthlyTotals[type] ?? 0;
+                return (
+                  <div key={type} className="rounded-md border border-border p-3">
+                    <div className="text-xs text-muted-foreground">{label}</div>
+                    <div className="text-lg font-semibold">{total} 分</div>
+                  </div>
+                );
+              })}
+            </div>
           )}
         </CardContent>
       </Card>

--- a/src/components/log/session-card.tsx
+++ b/src/components/log/session-card.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import Link from "next/link";
+import dayjs from "dayjs";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import type { SessionRecord } from "@/lib/datastore/local";
+
+export type Session = SessionRecord;
+
+export const SESSION_TYPE_LABELS: Record<string, string> = {
+  striking: "打撃",
+  wrestling: "レスリング",
+  grappling: "グラップリング",
+  tactics: "戦術",
+};
+
+export function SessionCard({ session }: { session: Session }) {
+  const dateTime = session.startTime ? dayjs(`${session.date} ${session.startTime}`) : dayjs(session.date);
+  const dateLabel = session.startTime ? dateTime.format("YYYY/MM/DD HH:mm") : dateTime.format("YYYY/MM/DD");
+
+  return (
+    <div className="space-y-2 rounded-lg border border-border p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="text-sm font-medium text-muted-foreground">{dateLabel}</div>
+        <div className="flex items-center gap-1">
+          <div className="flex items-center gap-2 text-sm font-medium">
+            <Badge>{SESSION_TYPE_LABELS[session.type] ?? session.type}</Badge>
+            <span>{session.durationMin} 分</span>
+          </div>
+          <Button asChild size="sm" variant="ghost">
+            <Link href={`/log/${session.id}/edit`}>編集</Link>
+          </Button>
+        </div>
+      </div>
+
+      {session.tags?.length ? (
+        <div className="flex flex-wrap gap-2">
+          {session.tags.map((tag, index) => (
+            <Badge key={`${session.id}-tag-${index}`} variant="outline">
+              #{tag}
+            </Badge>
+          ))}
+        </div>
+      ) : null}
+
+      {session.memo ? (
+        <p className="whitespace-pre-wrap text-sm leading-relaxed">{session.memo}</p>
+      ) : null}
+
+      {session.syncState !== "synced" ? (
+        <div className="text-xs text-amber-600">
+          {session.syncState === "pending" ? "同期待ち" : "同期エラー"}
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- replace the home screen recommendation tiles with a calendar-driven log browser
- allow selecting any date to view the recorded sessions and show monthly totals
- extract a reusable session card component and reuse it on the log list page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e12f5cb394832cb6cfcab6dd599a3a